### PR TITLE
ONEM-33238 RDKCMF-8937 LISA: add a function to retrieve dac config

### DIFF
--- a/LISA/Archives.cpp
+++ b/LISA/Archives.cpp
@@ -24,6 +24,7 @@
 #include <archive_entry.h>
 
 #include <memory>
+#include <cassert>
 
 namespace WPEFramework {
 namespace Plugin {

--- a/LISA/Config.cpp
+++ b/LISA/Config.cpp
@@ -91,6 +91,15 @@ Config::Config(const std::string& aConfig)
             else if (it->first == DOWNLOAD_TIMEOUT_SECS_KEY_NAME) {
                 downloadTimeoutSeconds = it->second.get_value<unsigned int>();
             }
+            else if (it->first == DACBUNDLEPLATFORMNAMEOVERRIDE_KEY_NAME) {
+                dacBundlePlatformNameOverride = it->second.get_value<std::string>();
+            }
+            else if (it->first == DACBUNDLEFIRMWARECOMPATIBILITYKEY_KEY_NAME) {
+                dacBundleFirmwareCompatibilityKey = it->second.get_value<std::string>();
+            }
+            else if (it->first == ASMS_URL_KEY_NAME) {
+                asmsUrl = it->second.get_value<std::string>();
+            }
         }
     }
     catch(std::exception& exc) {
@@ -143,6 +152,21 @@ unsigned int Config::getDownloadTimeoutSeconds() const
     return downloadTimeoutSeconds;
 }
 
+const std::string& Config::getDacBundlePlatformNameOverride() const
+{
+    return dacBundlePlatformNameOverride;
+}
+
+const std::string& Config::getDacBundleFirmwareCompatibilityKey() const
+{
+    return dacBundleFirmwareCompatibilityKey;
+}
+
+const std::string& Config::getAsmsUrl() const
+{
+    return asmsUrl;
+}
+
 std::ostream& operator<<(std::ostream& out, const Config& config)
 {
     return out << "[appsPath: " << config.appsPath << " tmpPath: " << config.appsTmpPath << " appStoragePath: "
@@ -152,6 +176,9 @@ std::ostream& operator<<(std::ostream& out, const Config& config)
                << " downloadRetryAfterSeconds: " << config.downloadRetryAfterSeconds
                << " downloadRetryMaxTimes: " << config.downloadRetryMaxTimes
                << " downloadTimeoutSeconds: " << config.downloadTimeoutSeconds
+               << " dacBundlePlatformNameOverride: " << config.dacBundlePlatformNameOverride
+               << " dacBundleFirmwareCompatibilityKey: " << config.dacBundleFirmwareCompatibilityKey
+               << " asmsUrl: " << config.asmsUrl
             << "]";
 };
 

--- a/LISA/Config.h
+++ b/LISA/Config.h
@@ -25,6 +25,13 @@ namespace WPEFramework {
 namespace Plugin {
 namespace LISA {
 
+const std::string DAC_CONFIG_MIMETYPE{"application/LISA"};
+const std::string DAC_CONFIG_APP_ID{"lisa.dac.config"};
+const std::string DAC_CONFIG_APP_VERSION{"0"};
+const std::string DACBUNDLEPLATFORMNAMEOVERRIDE_KEY_NAME{"dacBundlePlatformNameOverride"};
+const std::string DACBUNDLEFIRMWARECOMPATIBILITYKEY_KEY_NAME{"dacBundleFirmwareCompatibilityKey"};
+const std::string ASMS_URL_KEY_NAME{"asmsUrl"};
+
 class Config
 {
 public:
@@ -40,6 +47,9 @@ public:
     unsigned int getDownloadRetryAfterSeconds() const;
     unsigned int getDownloadRetryMaxTimes() const;
     unsigned int getDownloadTimeoutSeconds() const;
+    const std::string& getDacBundlePlatformNameOverride() const;
+    const std::string& getDacBundleFirmwareCompatibilityKey() const;
+    const std::string& getAsmsUrl() const;
 
     friend std::ostream& operator<<(std::ostream& out, const Config& config);
 
@@ -53,6 +63,9 @@ private:
     unsigned int downloadRetryAfterSeconds{30};
     unsigned int downloadRetryMaxTimes{4};
     unsigned int downloadTimeoutSeconds{15 * 60};
+    std::string dacBundlePlatformNameOverride;
+    std::string dacBundleFirmwareCompatibilityKey;
+    std::string asmsUrl;
 };
 
 } // namespace LISA

--- a/LISA/Executor.cpp
+++ b/LISA/Executor.cpp
@@ -494,6 +494,20 @@ uint32_t Executor::GetMetadata(const std::string& type,
                          const std::string& version,
                          DataStorage::AppMetadata& metadata) const
 {
+    if (type == DAC_CONFIG_MIMETYPE && id == DAC_CONFIG_APP_ID
+            && version == DAC_CONFIG_APP_VERSION) {
+        metadata.appDetails.id = DAC_CONFIG_APP_ID;
+        metadata.appDetails.type = DAC_CONFIG_MIMETYPE;
+        metadata.appDetails.version = DAC_CONFIG_APP_VERSION;
+        metadata.metadata.emplace_back(DACBUNDLEPLATFORMNAMEOVERRIDE_KEY_NAME,
+                                                     config.getDacBundlePlatformNameOverride());
+        metadata.metadata.emplace_back(DACBUNDLEFIRMWARECOMPATIBILITYKEY_KEY_NAME,
+                                                     config.getDacBundleFirmwareCompatibilityKey());
+        metadata.metadata.emplace_back(ASMS_URL_KEY_NAME,
+                                       config.getAsmsUrl());
+        return ERROR_NONE;
+    }
+
     if (type.empty() || id.empty() || version.empty()) {
         return ERROR_WRONG_PARAMS;
     }

--- a/LISA/SqlDataStorage.cpp
+++ b/LISA/SqlDataStorage.cpp
@@ -23,6 +23,7 @@
 #include <fstream>
 #include <string.h>
 #include <sstream>
+#include <cassert>
 
 #ifndef SQLITE_FILE_HEADER
 #define SQLITE_FILE_HEADER "SQLite format 3"


### PR DESCRIPTION
* extend getMetadata() to return dac configuration when passing specific values for type, id and version (see below)
* LISA retrieves these from its config file (LISA.json)

SENDING:
{
    "method": "LISA.1.getMetadata",
    "params": {
        "id": "lisa.dac.config",
        "type": "application/LISA",
        "version": "0"
    },
    "id": 844309,
    "jsonrpc": "2.0"
}

RECEIVED:
{
    "jsonrpc": "2.0",
    "id": 844309,
    "result": {
        "appName": "LISA",
        "category": "",
        "url": "",
        "auxMetadata": [
            {
                "key": "dacBundlePlatformNameOverride",
                "value": "VIP7002W"
            },
            {
                "key": "dacBundleFirmwareCompatibilityKey",
                "value": "0.1.3-70bb2a370ec7f7e3a1c4a95c6f51924dc55712cf-dbg"
            },
            {
                "key": "asmsUrl",
                "value": "http://xxxxxxxx"
            }
        ]
    }
}